### PR TITLE
Switched GENAVB_TSN_DEMO_APPS variable assignment to a soft assignment

### DIFF
--- a/recipes-extended/genavb-tsn/genavb-tsn.bb
+++ b/recipes-extended/genavb-tsn/genavb-tsn.bb
@@ -11,7 +11,7 @@ SRC_URI:append = " \
 
 PR = "r0"
 
-GENAVB_TSN_DEMO_APPS = "1"
+GENAVB_TSN_DEMO_APPS ?= "1"
 
 RDEPENDS:${PN}:append = " kernel-module-genavb-tsn"
 


### PR DESCRIPTION
I noticed that `GENAVB_TSN_DEMO_APPS` was set using a hard assignment. I think it makes sense to switch this to a soft assignment so it can easily be changed using bbappends and other methods. This soft assignment will only set `GENAVB_TSN_DEMO_APPS` to 1 if it has not already been set to some other value.

I didn't see contribution guidelines, so let me know if this needs to be sent somewhere else.